### PR TITLE
Anpassung Datenwerte der Variable 'behandlungsgruppe_level_2'

### DIFF
--- a/Metadaten/schemas/Intensivregister_Bundeslaender_Kapazitaeten.csvs
+++ b/Metadaten/schemas/Intensivregister_Bundeslaender_Kapazitaeten.csvs
@@ -4,7 +4,7 @@ datum: xDate
 bundesland_id: any("01","02","03","04","05","06","07","08","09","10","11","12","13","14","15","16")
 bundesland_name: any("Baden-Württemberg", "Bayern","Berlin","Brandenburg","Bremen","Hamburg","Hessen","Mecklenburg-Vorpommern", "Niedersachsen", "Nordrhein-Westfalen", "Rheinland-Pfalz", "Saarland", "Sachsen", "Sachsen-Anhalt","Schleswig-Holstein","Thüringen")
 behandlungsgruppe: is("Erwachsene")
-behandlungsgruppe_level_2: is("NA")
+behandlungsgruppe_level_2: is("ERWACHSENE")
 anzahl_meldebereiche: positiveInteger or is("NA")
 faelle_covid_aktuell: positiveInteger or is("NA")
 faelle_covid_erstaufnahmen: positiveInteger or is("NA")

--- a/Metadaten/schemas/Intensivregister_Deutschland_Kapazitaeten.csvs
+++ b/Metadaten/schemas/Intensivregister_Deutschland_Kapazitaeten.csvs
@@ -4,7 +4,7 @@ datum: xDate
 bundesland_id: is("00")
 bundesland_name: is("Deutschland")
 behandlungsgruppe: any("Erwachsene", "Kinder")
-behandlungsgruppe_level_2: any("NICU", "PICU", "ERWACSHENE")
+behandlungsgruppe_level_2: any("NICU", "PICU", "ERWACHSENE")
 anzahl_meldebereiche: positiveInteger or is("NA")
 faelle_covid_aktuell: positiveInteger or is("NA")
 faelle_covid_erstaufnahmen: positiveInteger or is("NA")

--- a/Metadaten/schemas/Intensivregister_Deutschland_Kapazitaeten.csvs
+++ b/Metadaten/schemas/Intensivregister_Deutschland_Kapazitaeten.csvs
@@ -4,7 +4,7 @@ datum: xDate
 bundesland_id: is("00")
 bundesland_name: is("Deutschland")
 behandlungsgruppe: any("Erwachsene", "Kinder")
-behandlungsgruppe_level_2: any("NICU", "PICU", "NA")
+behandlungsgruppe_level_2: any("NICU", "PICU", "ERWACSHENE")
 anzahl_meldebereiche: positiveInteger or is("NA")
 faelle_covid_aktuell: positiveInteger or is("NA")
 faelle_covid_erstaufnahmen: positiveInteger or is("NA")


### PR DESCRIPTION
behandlungsgruppe_level_2 wird jetzt in der Bereitstellung für Erwachsene mit "ERWACHSENE" ausgefüllt und nicht mehr mit "NA"